### PR TITLE
#31 #37 - Use inputHeight prop to actually set the height of the input

### DIFF
--- a/index.js
+++ b/index.js
@@ -386,8 +386,12 @@ class Search extends PureComponent {
 
 const getStyles = (inputHeight, isRtl) => {
   let middleHeight = 20
-  if (typeof inputHeight == 'number')
-  middleHeight = (10 + inputHeight) / 2;
+  if (typeof inputHeight == 'number') {
+    middleHeight = (10 + inputHeight) / 2;
+  } else{
+    // Default value for when prop value is not present
+    inputHeight = 30
+  }
 
   return {
     container: {

--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ import {
 } from 'react-native';
 
 const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
-const containerHeight = 40;
 
 class Search extends PureComponent {
   constructor(props) {
@@ -393,14 +392,14 @@ const getStyles = (inputHeight, isRtl) => {
   return {
     container: {
       backgroundColor: 'grey',
-      height: containerHeight,
+      height: inputHeight + 10,
       flexDirection: isRtl ? 'row-reverse' : 'row',
       justifyContent: 'flex-start',
       alignItems: 'center',
       padding: 5
     },
     input: {
-      height: containerHeight - 10,
+      height: inputHeight,
       paddingTop: 5,
       paddingBottom: 5,
       [isRtl ? 'paddingRight' : 'paddingLeft']: 20,


### PR DESCRIPTION
The `containerHeight` was previously hardcoded to `40`, meaning that `inputHeight` prop was not actually useful if you wanted to go taller than 40.

This pull request changes the height of both the Container and the Input to respect the passed `inputHeight` prop, which also fixes issue #31 . The existing default of `30` for Input Height is maintained, along with the Container height of `40` via the formula `inputHeight +  10` set in the Stylesheet
